### PR TITLE
Fix loading BLSTM model from disk under different path

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ The process for adding a new state extraction method is the following:
 - Konrad Wolsing (Fraunhofer FKIE & RWTH Aachen University)
 - Lea Thiemt (RWTH Aachen University)
 - Sven Zemanek (Fraunhofer FKIE)
+- Dominik Kus (RWTH Aachen University)
 
 ## License
 

--- a/ids/classifier/BLSTM.py
+++ b/ids/classifier/BLSTM.py
@@ -219,8 +219,10 @@ class BLSTM(FeatureIDS):
         if self.settings["model-file"] is None:
             return False
 
+        model_file_path = self._resolve_model_file_path()
+
         try:  # Open model file
-            with self._open_file(self._resolve_model_file_path(), mode="rt") as f:
+            with self._open_file(model_file_path, mode="rt") as f:
                 model = json.load(f)
 
         except FileNotFoundError:
@@ -235,9 +237,7 @@ class BLSTM(FeatureIDS):
         super().load_trained_model(model["preprocessors"])
         self.parameters = model["parameters"]
         self.history = model["history"]
-        self.blstm = tensorflow.keras.models.load_model(
-            self.settings["model-file"] + ".kreas"
-        )
+        self.blstm = tensorflow.keras.models.load_model(str(model_file_path) + ".kreas")
 
         return True
 


### PR DESCRIPTION
First of all, thanks for the useful framework! I found a minor issue with loading BLSTM models from disk.

When loading a BLSTM model from disk using a different path than was used when saving (e.g., because the data was moved in the filesystem), the keras model cannot be loaded.
This is because the keras-directory is searched for in a different location than specified in the config.

### Reproduction

Train and save a BLSTM model under `./model.pickle` (i.e., by setting `model-file` to that path).
Move the saved model into a subfolder `model` and try to load it by updating the `model-file` parameter to `./model/model.pickle`.
This fails because of the following:
- First, the model settings are loaded from `./model/model.pickle`. This overwrites the `model-file` setting to the value it had when saving: `./model.pickle`.
- Now, the keras data is loaded from `./model.pickle.keras` which does not exist (instead of `./model/model.pickle.keras`, as expected).