### PR TITLE
Setup.py lacks scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "tr",
         "pandas",
         "gurobipy",
+        "scikit-learn",
     ],
     tests_require=["pytest"],
     url="https://github.com/fkie-cad/ipal_ids_framework",


### PR DESCRIPTION
Setup.py was lacking scikit-learn, causing ipal-iids to not work after `pip install .`